### PR TITLE
Add option for 32-bit DLL

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@ module.exports = {
     SimpleController: require('./src/utils/SimpleController'),
     Manager: require('./src/BotManager'),
     quickChats: require('./src/utils/quickchats'),
-    GameStateUtil: require('./src/utils/GameState')
+    GameStateUtil: require('./src/utils/GameState'),
+    SuperDuperSecretStructuresThatNoOneIsAllowedToUse: require('./src/utils/flatstructs')
 }

--- a/src/pythonAgent/JSPythonAgent.py
+++ b/src/pythonAgent/JSPythonAgent.py
@@ -18,8 +18,10 @@ class BaseDotNetAgent(BaseIndependentAgent):
 
     def run_independently(self, terminate_request_event):
 
+        dll_path = game_interface.get_dll_32_directory() if game_interface.is_32_bit_python() else game_interface.get_dll_directory()
+
         while not terminate_request_event.is_set():
-            message = f"add\n{self.name}\n{self.team}\n{self.index}\n{game_interface.get_dll_directory()}"
+            message = f"add\n{self.name}\n{self.team}\n{self.index}\n{dll_path}"
             try:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 s.connect(("127.0.0.1", self.port))

--- a/src/pythonAgent/JSPythonAgent.py
+++ b/src/pythonAgent/JSPythonAgent.py
@@ -9,7 +9,7 @@ from rlbot.botmanager.helper_process_request import HelperProcessRequest
 from rlbot.utils.structures import game_interface
 
 
-class BaseDotNetAgent(BaseIndependentAgent):
+class BaseJavaScriptAgent(BaseIndependentAgent):
 
     def __init__(self, name, team, index):
         super().__init__(name, team, index)


### PR DESCRIPTION
This pr should allow RLBotJS to run on a 32-bit pc. 

I've basically copied https://github.com/RLBot/RLBot/blob/master/src/main/python/rlbot/utils/structures/game_interface.py#L57 into the python agent. This just makes it get the 32-bit DLL if the pc is 32-bit.